### PR TITLE
OSX fix for libtoolize call

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -17,11 +17,16 @@ echo autoheader...
 autoheader
 
 echo libtoolize...
+LIBTOOLIZE=libtoolize
 (libtoolize --version) < /dev/null > /dev/null 2>&1 || {
     echo libtoolize not found
-    exit 1
+    (glibtoolize --version) < /dev/null > /dev/null 2>&1 || {
+        echo gliboolize not found
+        exit 1
+    }
+    LIBTOOLIZE=glibtoolize
 }
-libtoolize --automake --copy --force
+$LIBTOOLIZE --automake --copy --force
 
 echo automake...
 (automake --version) < /dev/null > /dev/null 2>&1 || {


### PR DESCRIPTION
On OSX libtoolize does not exist, only glibtoolize.  Added a
fallback check to glibtoolize in the standard AM fashion.
https://bugs.launchpad.net/varconf/+bug/994171
