### PR TITLE
Alternative fix for https://bugs.launchpad.net/varconf/+bug/994171

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,42 +1,12 @@
 #! /bin/sh
 
-rm -f config.cache
+builddir=$(pwd)
+srcdir=$(dirname $0)
+test -z "$srcdir" && srcdir=.
+cd $srcdir
 
-echo aclocal...
-(aclocal --version) < /dev/null > /dev/null 2>&1 || {
-    echo aclocal not found
-    exit 1
-}
-aclocal $ACLOCAL_FLAGS
-
-echo autoheader...
-(autoheader --version) < /dev/null > /dev/null 2>&1 || {
-    echo autoheader not found
-    exit 1
-}    
-autoheader
-
-echo libtoolize...
-(libtoolize --version) < /dev/null > /dev/null 2>&1 || {
-    echo libtoolize not found
-    exit 1
-}
-libtoolize --automake --copy --force
-
-echo automake...
-(automake --version) < /dev/null > /dev/null 2>&1 || {
-    echo automake not found
-    exit 1
-}
-automake --add-missing --copy --gnu
-
-echo autoconf...
-(autoconf --version) < /dev/null > /dev/null 2>&1 || {
-    echo autoconf not found
-    exit 1
-}
-autoconf
+autoreconf --install || exit 1
 
 echo Ready to configure
-
+cd $builddir
 exit 0


### PR DESCRIPTION
Replace explicit calls to various autotools with the metatool supplied for that
purpose (lp: #994171).
